### PR TITLE
Add a check for FSA memory full

### DIFF
--- a/cpp/fsa.h
+++ b/cpp/fsa.h
@@ -236,7 +236,7 @@ public: // methods
 			);
 	}
 
-	unsigned int GetMaxElementCount(){ return m_MaxElements; };
+	unsigned int GetMaxElementCount() { return m_MaxElements; };
 
 public: // data
 

--- a/cpp/fsa.h
+++ b/cpp/fsa.h
@@ -236,6 +236,8 @@ public: // methods
 			);
 	}
 
+	unsigned int GetMaxElementCount(){ return m_MaxElements; };
+
 public: // data
 
 private: // methods

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -197,10 +197,16 @@ public: // methods
 			return m_State; 
 		}
 
+		bool maxNodesReached = false;
+		#if USE_FSA_MEMORY
+		maxNodesReached = m_AllocateNodeCount >= m_FixedSizeAllocator.GetMaxElementCount();
+		#endif
+
 		// Failure is defined as emptying the open list as there is nothing left to 
 		// search...
-		// New: Allow user abort
-		if( m_OpenList.empty() || m_CancelRequest )
+		// Allow user abort
+		// Check if FSA memory is full
+		if( m_OpenList.empty() || m_CancelRequest || maxNodesReached)
 		{
 			FreeAllNodes();
 			m_State = SEARCH_STATE_FAILED;


### PR DESCRIPTION
If the FSA memory cannot allocate more nodes, the search will now fail explicitly.
Before, this behavior would also cause the search to fail but was not an explicit check so it could have other results.

Maybe there should be a different fail state or a reason for failure too, but this works for now.